### PR TITLE
Version 0.3.2-a (22 Accepted)

### DIFF
--- a/source/common/api.rst
+++ b/source/common/api.rst
@@ -44,6 +44,7 @@ The below table indicates the two-digit USC-IR status codes to be used by the se
 ``statusCode`` Title         Meaning
 ============== ============= =======
 20             Success       Request succeeded.
+22             Accepted      Request was received, but not yet acted upon.
 40             Bad Request   The request was malformed.
 41             Unauthorized  No token, or an invalid token, was provided.
 42             Chart Refused The server is not accepting scores for this chart.
@@ -66,7 +67,7 @@ Returned JSON objects will *always* have these keys.
      - Type
      - Description
    * - ``statusCode``
-     - 20 | 40 | 41 | 42 | 43 | 44 | 50
+     - 20 | 22 | 40 | 41 | 42 | 43 | 44 | 50
      - See table above.
    * - ``description``
      - String

--- a/source/common/meta.rst
+++ b/source/common/meta.rst
@@ -3,6 +3,6 @@ Spec Information
 
 The USC-IR spec follows `Semantic Versioning <https://semver.org>`_.
 
-The current version of this spec is ``v0.3.1-a``.
+The current version of this spec is ``v0.3.2-a``.
 
 There's not really much more to it! This is intended to be a simple, clean spec, implemented by anyone.

--- a/source/conf.py
+++ b/source/conf.py
@@ -22,7 +22,7 @@ copyright = '2020, winter, zkldi'
 author = 'winter, zkldi'
 
 # The full version, including alpha/beta/rc tags
-release = '0.3.1-a'
+release = '0.3.2-a'
 
 # -- General configuration ---------------------------------------------------
 

--- a/source/endpoints/score-submit.rst
+++ b/source/endpoints/score-submit.rst
@@ -134,6 +134,7 @@ Expected Response
 ################
 
 | If the server refuses to track this chart, e.g. because it is blacklisted, or because the server does not know of it and rejects unknown charts, it should respond with ``statusCode 42``.
+| If the server has received the score, but is holding it in a queue, e.g. for servers which only begin displaying new charts after a certain number of unique players submit scores for it, it should respond with ``statusCode 22``.
 
 Otherwise, returns the standard API response, with ``body`` as follows:
 


### PR DESCRIPTION
Adds a new status code, 22 Accepted (an analogue of HTTP 202 Accepted), which is used in POST /scores to indicate that the score is received, but is being held in a queue.

This is useful for cases where the server only begins to track new charts properly after receiving scores on it from a specific number of unique users.

This was requested in #8.